### PR TITLE
Update mapping for the new Gigabyte Aorus Pro WiFi rev 1.2

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC1220-VB-Desktop-Rev-2-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC1220-VB-Desktop-Rev-2-HiFi.conf
@@ -1,0 +1,60 @@
+SectionDevice."Speaker" {
+	Comment "Speakers"
+	Value {
+		PlaybackChannels 8
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+		JackControl "Speaker Jack"
+		PlaybackMixerElem "Speaker"
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Front Headphones"
+	Value {
+		PlaybackPriority 300
+		PlaybackPCM "hw:${CardId},1"
+		JackControl "Front Headphone Jack"
+		PlaybackMixerElem "Front Headphone"
+	}
+}
+
+SectionDevice."SPDIF" {
+	Comment "S/PDIF Out"
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackMixerElem "IEC958"
+	}
+}
+
+SectionDevice."Line" {
+	Comment "Line In"
+	Value {
+		CapturePriority 100
+		CapturePCM "hw:${CardId}"
+		JackControl "Line Jack"
+		CaptureMixerElem "Line"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Microphone"
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},2"
+		JackControl "Mic Jack"
+		CaptureMixerElem "Mic"
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Front Microphone"
+	Value {
+		CapturePriority 300
+		CapturePCM "hw:${CardId},2"
+		JackControl "Front Mic Jack"
+		CaptureMixerElem "Front Mic"
+	}
+}
+

--- a/ucm2/USB-Audio/Realtek/ALC1220-VB-Desktop-Rev-2.conf
+++ b/ucm2/USB-Audio/Realtek/ALC1220-VB-Desktop-Rev-2.conf
@@ -1,0 +1,5 @@
+Comment "USB-audio on Realtek ALC1220-VB desktop rev 1.2"
+SectionUseCase."HiFi" {
+	File "/USB-Audio/Realtek/ALC1220-VB-Desktop-Rev-2-HiFi.conf"
+	Comment "Default Alsa Profile"
+}

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -27,6 +27,17 @@ If.realtek-alc1220-vb {
 		Regex "USB((0414:a002)|(0b05:191[78])|(0db0:(0d64|543d))|(26ce:0a01))"
 	}
 	True.Define.ProfileName "Realtek/ALC1220-VB-Desktop"
+	False {
+	  If.realtek-alc1220-vb {
+	    Condition {
+	      Type RegexMatch
+	      String "${CardComponents}"
+	      # 0414:a00d Gigabyte TRX40 Aorus Pro WiFi Rev 1.2
+	      Regex "USB((0414:a00d))"
+	    }
+	    True.Define.ProfileName "Realtek/ALC1220-VB-Desktop-Rev-2"
+    }
+  }
 }
 
 If.realtek-alc4080 {


### PR DESCRIPTION
Requires https://github.com/pop-os/linux/pull/141

This should work for all rear IO should now work (Mic/Speakers/Line-In/Toslink). Front Mic is still broken. Currently waiting on upstream to see if they have a solution. Though this should be good enough for us to start selling Thelio Major's until that is patched, because Thelios don't currently have front IO. 