### PR TITLE
Fix rear audio jacks on Thelio Mega R1.1

### DIFF
--- a/ucm2/USB-Audio/Gigabyte/Aorus-Master-Main-Audio-HiFi.conf
+++ b/ucm2/USB-Audio/Gigabyte/Aorus-Master-Main-Audio-HiFi.conf
@@ -1,5 +1,3 @@
-Define.SecondaryCardId "$${find-card:field=name,return=id,regex='Aorus Master Front Headphone'"
-
 SectionDevice."Speaker" {
 	Comment "Speakers"
 	Value {
@@ -8,16 +6,6 @@ SectionDevice."Speaker" {
 		PlaybackPCM "hw:${CardId}"
 		JackControl "Line Out Jack"
 		PlaybackMixerElem "Line Out"
-	}
-}
-
-SectionDevice."Headphones" {
-	Comment "Front Headphones"
-	Value {
-		PlaybackPriority 300
-		PlaybackPCM "hw:${var:SecondaryCardId}"
-		JackCTL "hw:${var:SecondaryCardId}"
-		JackControl "Headphone - Output Jack"
 	}
 }
 


### PR DESCRIPTION
The secondary card doesn't appear properly to alsa-ucm-conf. This
is causing the whole config to fail. Removing that import causes
the correct config to be loaded, thus working jacks.

Requires https://github.com/pop-os/linux/pull/167