### PR TITLE
USB-Audio: alc4080 - add MSI MAG B650I Edge WiFi (ID 0db0:36e7)

### DIFF
--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -43,7 +43,8 @@ If.realtek-alc4080 {
 		# 0db0:1feb MSI Edge Wifi Z690
 		# 0db0:419c MSI MPG X570S Carbon Max Wifi
 		# 0db0:a073 MSI MAG X570S Torpedo Max
-		Regex "USB((0b05:(199[69]|1a2[07]|1984))|(0db0:(1feb|419c|a073|82c7)))"
+		# 0db0:36e7 MSI MAG B650I Edge WiFi
+		Regex "USB((0b05:(199[69]|1a2[07]|1984))|(0db0:(1feb|419c|a073|82c7|36e7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
This should fix thelio-r3 audio issues

[Upstreamed here.](https://github.com/alsa-project/alsa-ucm-conf/pull/254)