### PR TITLE
USB-Audio: ALC4080 - add wrx80e sage se wifi (ID: 0b05:1984)

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -88,6 +88,19 @@ If.asus-rog-usb {
 	}
 }
 
+If.wrx80-sage {
+	Condition {
+		Type RegexMatch
+		String "${CardComponents}"
+		Regex "USB(0b05:1984)"
+	}
+	True.Define {
+		Mic2Mixer "Analog In"
+		Mic2Jack "Analog In - Input Jack"
+		Mic2PCM "hw:${CardId}"
+	}
+}
+
 If.msi-meg-unify {
 	Condition {
 		Type RegexMatch

--- a/ucm2/USB-Audio/USB-Audio.conf
+++ b/ucm2/USB-Audio/USB-Audio.conf
@@ -45,6 +45,7 @@ If.realtek-alc4080 {
 		Type RegexMatch
 		String "${CardComponents}"
 		# 0414:a00e Gigabyte Z590 Aorus Pro AX
+		# 0b05:1984 ASUS Pro WS WRX80E-SAGE SE WIFI
 		# 0b05:1996 ASUS on multiple boards (including ASUS ROG Maximus XIII)
 		# 0b05:1999 ASUS ROG Strix Z590-A Gaming WiFi
 		# 0b05:1a16 ASUS ROG Strix B660-F Gaming WiFi
@@ -68,7 +69,7 @@ If.realtek-alc4080 {
 		# 0db0:b202 MSI MAG Z690 Tomahawk Wifi
 		# 0db0:d1d7 MSI PRO Z790-A WIFI
 		# 0db0:d6e7 MSI MPG X670E Carbon Wifi
-		Regex "USB((0414:a00e)|(0b05:(199[69]|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|62a4|6c[0c]9|82c7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
+		Regex "USB((0414:a00e)|(0b05:(19(9[69]|84)|1a(16|2[07]|5[23])))|(0db0:(005a|151f|1feb|36e7|419c|62a4|6c[0c]9|82c7|961e|a073|a47c|a74b|b202|d1d7|d6e7)))"
 	}
 	True.Define.ProfileName "Realtek/ALC4080"
 }


### PR DESCRIPTION
This motherboard is recognized by system76 as the mega-r2