### PR TITLE
USB-Audio: ALC4080 - MSI MPG Z790I (ID: 0db0:62a4)

### DIFF
--- a/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
+++ b/ucm2/USB-Audio/Realtek/ALC4080-HiFi.conf
@@ -130,7 +130,7 @@ If.no-spdif {
 	Condition {
 		Type RegexMatch
 		String "${CardComponents}"
-		Regex "USB(0db0:36e7)"
+		Regex "USB(0db0:(36e7|62a4))"
 	}
 	True.Define {
 		SpdifName ""


### PR DESCRIPTION
Unfortunately this is the exact same bug as the thelio-r3, and only gets the b5 to the same partial fix state.